### PR TITLE
Correction multiply(a,b) = a * b

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -42,7 +42,7 @@ def multiply(a, b):
     Sortie:
         float: a élevé à la puissance b (a^b)
     """
-    return a ** b
+    return a * b
 
 def divide(a, b):
     """


### PR DESCRIPTION
La fonction multiply(a, b) utilisait l’opérateur ** (puissance) au lieu de * (multiplication), ce qui donnait des résultats erronés.
Correction : Remplace ** par * 
Résultats :
Les tests suivants passent maintenant :
test_calculate_valid_multiplication
test_calculate_decimal_numbers 
test_multiply_positive_numbers
test_multiply_negative_numbers